### PR TITLE
Fix platform test instructions

### DIFF
--- a/tests.md
+++ b/tests.md
@@ -32,7 +32,7 @@ meson compile -C build_arm openrtx_mytarget_flash
 ## Switch from test to OpenRTX
 To go back to compiling standard OpenRTX instead of a platform test you can type this command
 ```
-meson configure -Dtest=main build_arm
+meson configure -Dtest= build_arm
 ```
 Or simply delete your build folder with
 ```


### PR DESCRIPTION
According to https://github.com/OpenRTX/OpenRTX/blob/691b388/meson.build#L60-L64 the test option needs to be empty to trigger a main build.

73 IU5BON