### PR TITLE
Fix favicons

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,11 +7,11 @@
   <meta name="description" content="Free and Open Source Firmware for Digital Ham Radios">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
   <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify/lib/themes/dark.css" />
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
+  <link rel="mask-icon" href="/icons/safari-pinned-tab.svg" color="#5bbad5">
   <meta name="msapplication-TileColor" content="#fab413">
   <meta name="theme-color" content="#fab413">
 </head>


### PR DESCRIPTION
# What

In #17 I reported that the favicons were not loading, which is a minor UX impairment. The favicons existed, the `index.html` just had the wrong relative path. So fix that.

# Why

With this, my naive link checker shows that there are no dead links on the openrtx.org page. Once this is done, I can explore integrating a GitHub Action to avoid introducing new dead links. So this change in itself is somewhat helpful, but it is also an incremental change towards adding some stability to this project.

# How

Correct the relative path on the `index.html` file. This works because the files already exist and are being served properly.

```sh
➜  openrtx.github.io git:(fix/favicons) ✗ curl --remote-name-all http://localhost:3000/icons/\{apple-touch-icon.png,favicon-32x32.png,favicon-16x16.png,safari-pinned-tab.svg\} -s -w "%{http_code}\n"
200
200
200
200
```

So all that was needed was to add `/icons` to the hrefs.

# Verification

1. Load the index page in a Chrome desktop UA

Expected result: the OpenRTX logo appears as the favicon (in chrome, this is left of the omnibar)
Actual result: the OpenRTX logo appears

| Before | After |
| ------- | ---- |
| <img width="1624" alt="Screen Shot 2023-08-04 at 8 12 50 AM"  src="https://github.com/OpenRTX/openrtx.github.io/assets/701035/2d5a143f-0ba2-4e26-b495-4d14246f9151">  |  <img width="1624" alt="Screen Shot 2023-08-04 at 8 13 57 AM" src="https://github.com/OpenRTX/openrtx.github.io/assets/701035/efb8b47d-e529-4551-a1bb-036669f07771"> |
