### PR TITLE
Fix dead links with archive.org

### DIFF
--- a/hardware/uv878.md
+++ b/hardware/uv878.md
@@ -10,8 +10,8 @@
     * UHF: 400.0000-480.0000 (?)
 
 ## Additional Links
-*  [Jason Reilly's Anytone Mods and Techinfo Website](http://members.optuszoo.com.au/jason.reilly1/868mods.htm#Inside) 
-*  [Large Collection of Anytone Related Material](https://premier01.com/inf/?C=M;O=D)
+*  [Jason Reilly's Anytone Mods and Techinfo Website](https://web.archive.org/web/20220831184913/https://members.optuszoo.com.au/jason.reilly1/868mods.htm) 
+*  [Large Collection of Anytone Related Material](https://web.archive.org/web/20230102224956/https://premier01.com/inf/?C=M;O=D)
 
 The collection link is often referenced in the Anytone support facebook group and seems to be somehow directly related to the 
 
@@ -20,7 +20,7 @@ The collection link is often referenced in the Anytone support facebook group an
 
 ## Memory Map
 
-The memory map of the device is very well described in the [datasheet](https://www.gigadevice.com/microcontroller/gd32f303vgt6/). The firmware itself starts at 0x8004000 instead of 0x8000000 as the first 0x4000 bytes are taken by the bootloader.
+The memory map of the device is very well described in the [datasheet](https://web.archive.org/web/20230202004134/https://www.gigadevice.com/microcontroller/gd32f303vgt6/). The firmware itself starts at 0x8004000 instead of 0x8000000 as the first 0x4000 bytes are taken by the bootloader.
 
 ## Flashing
 
@@ -90,9 +90,9 @@ There is also a special SCT mode which allows direct communication to the baseba
 
 ### Downloads
 * [Baseband Flashtool, Update Hex Files and Guide](https://pwn.su/research/anytone/D8x8UV_Base_Band_Update_SCT3258.zip)
-* [Hardware Development Kit User Guide](https://www.cmlmicro.com/wp-content/uploads/2018/07/SCT3258_HDK_User_Guide_V1_9.pdf)
-* [GD32F303VGT6  datasheet](https://www.gigadevice.com/microcontroller/gd32f303vgt6/)
-* [SCT3258 to datasheet](https://www.cmlmicro.com/wp-content/uploads/2018/07/SCT3258_datasheet_v2_0.pdf)
+* [Hardware Development Kit User Guide](https://web.archive.org/web/20220518011541/https://cmlmicro.com/wp-content/uploads/2018/07/SCT3258_HDK_User_Guide_V1_9.pdf)
+* [GD32F303VGT6 datasheet](https://web.archive.org/web/20230202004134/https://www.gigadevice.com/microcontroller/gd32f303vgt6/)
+* [SCT3258 to datasheet](https://cdn.hackaday.io/files/1642237026116832/SCT3258_datasheet_v2_0.pdf)
 
 ## Linkboard (APRS and FSK)
 


### PR DESCRIPTION
# What

In looking around the docs, I noticed that there were 5 links to dead pages. Let's fix that.

# Why

This way it's easier for people to learn about the hardware support, and the website also seems more complete.

# How

In most cases, the last snapshot with the content from archive.org is being used. There is one instance where SCT3258_datasheet_v2_0.pdf is not captured by archive.org, so instead I've replaced the link with a popular website's CDN.

| Old link | New link |
|-------|------|
| http://members.optuszoo.com.au/jason.reilly1/868mods.htm#Inside | https://web.archive.org/web/20220831184913/https://members.optuszoo.com.au/jason.reilly1/868mods.htm |
| https://premier01.com/inf/?C=M;O=D | https://web.archive.org/web/20230102224956/https://premier01.com/inf/?C=M;O=D |
| https://www.gigadevice.com/microcontroller/gd32f303vgt6/ | https://web.archive.org/web/20230202004134/https://www.gigadevice.com/microcontroller/gd32f303vgt6/ |
| https://www.cmlmicro.com/wp-content/uploads/2018/07/SCT3258_HDK_User_Guide_V1_9.pdf | https://web.archive.org/web/20220518011541/https://cmlmicro.com/wp-content/uploads/2018/07/SCT3258_HDK_User_Guide_V1_9.pdf | 
| https://www.cmlmicro.com/wp-content/uploads/2018/07/SCT3258_datasheet_v2_0.pdf | https://cdn.hackaday.io/files/1642237026116832/SCT3258_datasheet_v2_0.pdf |

# Next steps

I still need to put automated checking in for dead links. When that happens, there may be follow-up MRs to correct other areas to.