### PR TITLE
Add pipeline for spelling

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,20 @@
+name: "Main"
+on:
+  workflow_dispatch:
+  push:
+  pull_request:
+jobs:
+  check-spelling:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: install cspell
+        run: |
+          cd ${{github.workspace}}
+          npm install -g cspell
+      - name: Check spelling
+        run: cspell **/*.md

--- a/dev_status.md
+++ b/dev_status.md
@@ -42,7 +42,7 @@ OpenRTX is currently in active development. There will be bugs as we prioritize 
 | Tytera MD-380 / MD-390         |  ✅   |  ✅    |   ✅    |   ✅   |   ❌     |   ❌     |   ❌   |   ❌    |   ❌    |
 | Tytera MD-UV380 / Retevis RT3s |  ✅   |  ✅    |   ✅    |   ✅   |   ❌     |   ❌     |   ❌   |   ❌    |   ❌    |
 | Radioddity GD-77               |  ✅   |  ✅    |   ❌    |   ❌   |   ❌     |   ❌     |   ❌   |   ❌    |   ❌    |
-| Baeofeng DM-1801               |  ✅   |  ✅    |   ❌    |   ❌   |   ❌     |   ❌     |   ❌   |   ❌    |   ❌    |
+| Baofeng DM-1801               |  ✅   |  ✅    |   ❌    |   ❌   |   ❌     |   ❌     |   ❌   |   ❌    |   ❌    |
 | Tytera MD-9600                 |  ❌   |  ❌    |   ❌    |   ❌    |   ❌    |   ❌     |   ❌    |  ❌    |   ❌    |
 
 _Tytera MD-9600 support is not yet complete, and as a result pre-made builds are not available._


### PR DESCRIPTION
Baofeng was misspelled, which is kind of silly since the cspell tool was setup to prevent this. Add a GitHub Action to avoid this issue sneaking past us again.