### PR TITLE
Fix mode lookup table on OBCF

### DIFF
--- a/binary_cps_format.md
+++ b/binary_cps_format.md
@@ -19,7 +19,7 @@ The OpenRTX Binary CPS Format (OBCF) is a binary data format for storing radio c
 
 ## Version control
 
-OBCF observed [Semantic Versioning v2.0.0](https://semver.org/spec/v2.0.0.html). This document is at **v0.1.0** of the standard presently. Errata not resulting in substantially different understandings, capabilities, or definitions may be treated as un-versioned revisions of this document without incrementing the patch versions. A detailed history of changes for this document may be viewed [on GitHub](https://github.com/OpenRTX/openrtx.github.io/commits/master/binary_cps_format.md).
+OBCF observed [Semantic Versioning v2.0.0](https://semver.org/spec/v2.0.0.html). This document is at **v0.1.1** of the standard presently. Errata not resulting in substantially different understandings, capabilities, or definitions may be treated as un-versioned revisions of this document without incrementing the patch versions. A detailed history of changes for this document may be viewed [on GitHub](https://github.com/OpenRTX/openrtx.github.io/commits/master/binary_cps_format.md).
 
 ## Specification
 
@@ -77,12 +77,13 @@ This structure is the beginning of the file. The fields are laid out in the foll
 
 #### Mode lookup table
 
-|   Bits | Value    | Notes                  |
-| -----: | -------- | ---------------------- |
-| `0b00` | FM       | Only used for channels |
-| `0b01` | DMR      |                        |
-| `0b10` | M17      |                        |
-| `0b11` | Reserved |                        |
+|                     Bits | Value    | Notes                                 |
+| -----------------------: | -------- | ------------------------------------- |
+|             `0b00000000` | None     | Indeterminate state for compatibility |
+|             `0b00000001` | FM       | Only used for channels                |
+|             `0b00000010` | DMR      |                                       |
+|             `0b00000011` | M17      |                                       |
+| `0b00000100..0b11111111` | Reserved |                                       |
 
 #### DMR contact type lookup table
 


### PR DESCRIPTION
# What

A couple of community members in M17 pointed out that the mode lookup table was misleadingly unexpanded given that the field had an entire byte. Fix this. I also discovered, more significantly, that the value of this table had an off-by-one error as a consequence of an inconsistency between the draft specification, which had included a typedef for this field, and the actual implementation in OpenRTX. Ill focus the rest of this PR explaining this.

# Why

When researching how the native CPS is implemented in openrtx, I noticed that `channel_t` is shared with present day native CPS and openrtx codeplug formats. This is when I discovered that the `enum opmode` definition is the proper definition for this mode field, which specifies that 0 is OPMODE_NONE, not OPMODE_FM. So this clearly needs to be fixed. And across all instances that I found, an entire uint8 was used for this representation. So the original idea of expanding the lookup table to a full byte remains.

# How

- Expand the lookup table to a byte
- Insert a new 0b0 value for "None" and document its use as a matter of compatibility for an indeterminate state