### PR TITLE
Update line ref to meson.build for CS7000P flashing

### DIFF
--- a/hardware/cs7000.md
+++ b/hardware/cs7000.md
@@ -99,7 +99,7 @@ Procedure follows:
 
 Make the following modifications:
 
-[meson.build](https://github.com/OpenRTX/OpenRTX/blob/master/meson.build) (currently on line 892)
+[meson.build](https://github.com/OpenRTX/OpenRTX/blob/master/meson.build) (currently on line 906)
 The code section looks like this:
 
 ```


### PR DESCRIPTION
This PR updates the line number where the address needs to be changed in `meson.build` for flashing OpenRTX to the CS7000P directly. It was previously line 892 and is now 906. It will always change eventually but no harm in updating it occasionally. Also auto-fixed the missing newline at the end of file.