### PR TITLE
Update tables on the Development Status page

### DIFF
--- a/dev_status.md
+++ b/dev_status.md
@@ -42,20 +42,21 @@ OpenRTX is currently in active development. There will be bugs as we prioritize 
 
 ### Modes
 
-| Radio model                    | FM RX | FM TX | M17 RX | M17 TX | APRS RX | APRS TX | DMR RX | DMR TX | DMR SMS |
-| ------------------------------ | :---: | :---: | :----: | :----: | :-----: | :-----: | :----: | :----: | :-----: |
-| Tytera MD-380 / MD-390         | ✅    | ✅    | ✅     | ✅     | ❌      | ❌      | ❌     | ❌     | ❌      |
-| Tytera MD-UV380 / Retevis RT3s | ✅    | ✅    | ✅     | ✅     | ❌      | ❌      | ❌     | ❌     | ❌      |
-| Radioddity GD-77               | ✅    | ✅    | N/A    | N/A    | ❌      | ❌      | ❌     | ❌     | ❌      |
-| Baofeng DM-1801                | ✅    | ✅    | N/A    | N/A    | ❌      | ❌      | ❌     | ❌     | ❌      |
-| Tytera MD-9600                 | ❌    | ❌    | ❌     | ❌     | ❌      | ❌      | ❌     | ❌     | ❌      |
-| Module 17                      | N/A   | N/A   | ✅     | ✅     | N/A     | N/A     | N/A    | N/A    | N/A     |
-| Lilygo T-TWR plus              | ✅    | ✅    | ❌     | ❌     | ❌      | ❌      | N/A    | N/A    | N/A     |
-| Radtel RT-890                  | ❌    | ❌    | ❌     | ❌     | ❌      | ❌      | ❌     | ❌     | ❌      |
-| Talkpod A36plus                | ✅    | ✅    | ❌     | ❌     | ❌      | ❌      | ❌     | ❌     | ❌      |
-| Retevis C62                    | ✅    | ❌    | ❌     | ❌     | ❌      | ❌      | ❌     | ❌     | ❌      |
-| Connect Systems CS7000-M17     | ✅    | ✅    | ✅     | ✅     | ❌      | ❌      | ❌     | ❌     | ❌      |
-| Connect Systems CS7000-M17 Plus| ✅    | ✅    | ✅     | ✅     | ❌      | ❌      | ❌     | ❌     | ❌      |
+| Radio model                                    |FM RX | FM TX | AM RX | M17 RX | M17 TX | APRS RX | APRS TX | DMR RX | DMR TX | DMR SMS |
+| -----------------------------------------------|:---: | :---: | :---: | :----: | :----: | :-----: | :-----: | :----: | :----: | :-----: |
+| Tytera MD-380 / MD-390 / Retevis RT3 **(VHF)** |✅    | ✅    | N/A   | ✅     | ❌     | ❌      | ❌      | ❌     | ❌     | ❌      |
+| Tytera MD-380 / MD-390 / Retevis RT3 **(UHF)** |✅    | ✅    | N/A   | ✅     | ✅     | ❌      | ❌      | ❌     | ❌     | ❌      |
+| Tytera MD-UV380 / Retevis RT3s                 |✅    | ✅    | N/A   | ✅     | ✅     | ❌      | ❌      | ❌     | ❌     | ❌      |
+| Radioddity GD-77                               |✅    | ✅    | N/A   | N/A    | N/A    | ❌      | ❌      | ❌     | ❌     | ❌      |
+| Baofeng DM-1801                                |✅    | ✅    | N/A   | N/A    | N/A    | ❌      | ❌      | ❌     | ❌     | ❌      |
+| Tytera MD-9600                                 |❌    | ❌    | N/A   | ❌     | ❌     | ❌      | ❌      | ❌     | ❌     | ❌      |
+| Module 17                                      |N/A   | N/A   | N/A   | ✅     | ✅     | N/A     | N/A     | N/A    | N/A    | N/A     |
+| Lilygo T-TWR plus                              |✅    | ✅    | N/A   | ❌     | ❌     | ❌      | ❌      | N/A    | N/A    | N/A     |
+| Radtel RT-890                                  |❌    | ❌    | N/A   | ❌     | ❌     | ❌      | ❌      | N/A    | N/A    | N/A     |
+| Talkpod A36plus                                |✅    | ✅    | 🟡    | ❌     | ❌     | ❌      | ❌      | N/A    | N/A    | N/A     |
+| Retevis C62                                    |✅    | ❌    | N/A   | ❌     | ❌     | ❌      | ❌      | ❌     | ❌     | ❌      |
+| Connect Systems CS7000-M17                     |✅    | ✅    | N/A   | ✅     | ✅     | ❌      | ❌      | ❌     | ❌     | ❌      |
+| Connect Systems CS7000-M17 Plus                |✅    | ✅    | N/A   | ✅     | ✅     | ❌      | ❌      | ❌     | ❌     | ❌      |
 
 
 ### Notes:

--- a/dev_status.md
+++ b/dev_status.md
@@ -25,37 +25,37 @@ OpenRTX is currently in active development. There will be bugs as we prioritize 
 
 ### Basic Functions
 
-| Radio model                    | Boot | Display | Keyboard | CPS | RTC | Persistence | GPS | Known Issues                                                                                                                     |
-| ------------------------------ | :--: | :-----: | :------: | :-: | :-: | :---------: | :-: | ------------------------------------------------------------------------------------ |
-| Tytera MD-380 / MD-390         |  ✅  |   ✅     |    ✅     | ✅  | ✅   |     ✅      | ✅  | [on GitHub](https://github.com/OpenRTX/OpenRTX/issues?q=is:open+label:MD-3x0,ALL)     |
-| Tytera MD-UV380 / Retevis RT3s |  ✅  |   ✅     |    ✅     | ✅  | ✅   |     ✅      | ✅  | [on GitHub](https://github.com/OpenRTX/OpenRTX/issues?q=is:open+label:MD-UV3x0,ALL)   |
-| Radioddity GD-77               |  ✅  |   ✅     |    ✅     | ✅  | N/A |     ❌      | N/A | [on GitHub](https://github.com/OpenRTX/OpenRTX/issues?q=is:open+label:GD-77,ALL)      |
-| Baofeng DM-1801                |  ✅  |   ✅     |    ✅     | ✅  | N/A |     ❌      | N/A | [on GitHub](https://github.com/OpenRTX/OpenRTX/issues?q=is:open+label:DM-1801,ALL)    |
-| Tytera MD-9600                 |  ✅  |   ✅     |    ✅     | ❌  | ✅   |     ❌      | ❌  | [on GitHub](https://github.com/OpenRTX/OpenRTX/issues?q=is:open+label:MD-9600,ALL)    |
-| Module 17                      |  ✅  |   ✅     |    ✅     | ❌  | ✅   |     ✅      | N/A | [on GitHub](https://github.com/OpenRTX/OpenRTX/issues?q=is:open+label:Module17,ALL)    |
-| Lilygo T-TWR plus              |  ✅  |   ✅     |    ✅     | ❌  | ✅   |     ❌      | ✅  | [on GitHub](https://github.com/OpenRTX/OpenRTX/issues?q=is:open+label:T-TWR%20Plus,ALL)|
-| Radtel RT-890                  |  ✅  |   🟡     |    ✅     | ❌  | N/A |     ❌      | N/A  | [on GitHub](https://github.com/OpenRTX/OpenRTX/issues?q=is:open+label:RT-890,ALL)    |
-| Talkpod A36plus                |  ✅  |   ✅     |    ✅     | ❌  | 🟡   |     ✅     | N/A  | [on GitHub](https://github.com/OpenRTX/OpenRTX/issues?q=is:open+label:A36plus,ALL)    |
-| Retevis C62                    |  ✅  |   ✅     |    ✅     | ❌  | ❌   |     ❌     | N/A  | [on GitHub](https://github.com/OpenRTX/OpenRTX/issues?q=is:open+label:retevis-c62,ALL)    |
-| Connect Systems CS7000-M17     |  ✅  |   ✅     |    ✅     | ❌  | N/A  |     ✅     | ✅   | [on GitHub](https://github.com/OpenRTX/OpenRTX/issues?q=is:open+label:CS7000,ALL)            |
-| Connect Systems CS7000-M17 Plus|  ✅  |   ✅     |    ✅     | ❌  | N/A  |     ✅     | ✅   | [on GitHub](https://github.com/OpenRTX/OpenRTX/issues?q=is:open+label:CS7000-Plus,ALL)|
+| Radio model                    | Boot | Display | Keyboard | CPS | RTC | Persistence | GPS | Known Issues                                                                            |
+| ------------------------------ | :--: | :-----: | :------: | :-: | :-: | :---------: | :-: | --------------------------------------------------------------------------------------- |
+| Tytera MD-380 / MD-390         | ✅   | ✅      | ✅       | ✅  | ✅  | ✅          | ✅  | [on GitHub](https://github.com/OpenRTX/OpenRTX/issues?q=is:open+label:MD-3x0,ALL)       |
+| Tytera MD-UV380 / Retevis RT3s | ✅   | ✅      | ✅       | ✅  | ✅  | ✅          | ✅  | [on GitHub](https://github.com/OpenRTX/OpenRTX/issues?q=is:open+label:MD-UV3x0,ALL)     |
+| Radioddity GD-77               | ✅   | ✅      | ✅       | ✅  | N/A | ❌          | N/A | [on GitHub](https://github.com/OpenRTX/OpenRTX/issues?q=is:open+label:GD-77,ALL)        |
+| Baofeng DM-1801                | ✅   | ✅      | ✅       | ✅  | N/A | ❌          | N/A | [on GitHub](https://github.com/OpenRTX/OpenRTX/issues?q=is:open+label:DM-1801,ALL)      |
+| Tytera MD-9600                 | ✅   | ✅      | ✅       | ❌  | ✅  | ❌          | ❌  | [on GitHub](https://github.com/OpenRTX/OpenRTX/issues?q=is:open+label:MD-9600,ALL)      |
+| Module 17                      | ✅   | ✅      | ✅       | ❌  | ✅  | ✅          | N/A | [on GitHub](https://github.com/OpenRTX/OpenRTX/issues?q=is:open+label:Module17,ALL)     |
+| Lilygo T-TWR plus              | ✅   | ✅      | ✅       | ❌  | ✅  | ❌          | ✅  | [on GitHub](https://github.com/OpenRTX/OpenRTX/issues?q=is:open+label:T-TWR%20Plus,ALL) |
+| Radtel RT-890                  | ✅   | 🟡      | ✅       | ❌  | N/A | ❌          | N/A | [on GitHub](https://github.com/OpenRTX/OpenRTX/issues?q=is:open+label:RT-890,ALL)       |
+| Talkpod A36plus                | ✅   | ✅      | ✅       | ❌  | 🟡  | ✅          | N/A | [on GitHub](https://github.com/OpenRTX/OpenRTX/issues?q=is:open+label:A36plus,ALL)      |
+| Retevis C62                    | ✅   | ✅      | ✅       | ❌  | ❌  | ❌          | N/A | [on GitHub](https://github.com/OpenRTX/OpenRTX/issues?q=is:open+label:retevis-c62,ALL)  |
+| Connect Systems CS7000-M17     | ✅   | ✅      | ✅       | ❌  | N/A | ✅          | ✅  | [on GitHub](https://github.com/OpenRTX/OpenRTX/issues?q=is:open+label:CS7000,ALL)       |
+| Connect Systems CS7000-M17 Plus| ✅   | ✅      | ✅       | ❌  | N/A | ✅          | ✅  | [on GitHub](https://github.com/OpenRTX/OpenRTX/issues?q=is:open+label:CS7000-Plus,ALL)  |
 
 ### Modes
 
 | Radio model                    | FM RX | FM TX | M17 RX | M17 TX | APRS RX | APRS TX | DMR RX | DMR TX | DMR SMS |
 | ------------------------------ | :---: | :---: | :----: | :----: | :-----: | :-----: | :----: | :----: | :-----: |
-| Tytera MD-380 / MD-390         |  ✅   |  ✅    |   ✅    |   ✅   |   ❌     |   ❌     |   ❌   |   ❌    |   ❌     |
-| Tytera MD-UV380 / Retevis RT3s |  ✅   |  ✅    |   ✅    |   ✅   |   ❌     |   ❌     |   ❌   |   ❌    |   ❌     |
-| Radioddity GD-77               |  ✅   |  ✅    |   N/A  |  N/A   |   ❌    |   ❌     |   ❌   |   ❌     |   ❌    |
-| Baofeng DM-1801                |  ✅   |  ✅    |   N/A  |  N/A   |   ❌    |   ❌     |   ❌   |   ❌     |   ❌    |
-| Tytera MD-9600                 |  ❌   |  ❌    |   ❌    |   ❌    |   ❌    |   ❌     |   ❌    |  ❌     |   ❌    |
-| Module 17                      |  N/A |  N/A   |   ✅    |   ✅    |   N/A  |  N/A    |  N/A   |  N/A   |   N/A   |
-| Lilygo T-TWR plus              |  ✅   |  ✅    |   ❌    |   ❌    |   ❌    |   ❌     |  N/A   |  N/A   |   N/A   |
-| Radtel RT-890                  |  ❌   |  ❌    |   ❌    |   ❌    |   ❌    |   ❌     |   ❌    |  ❌     |   ❌    |
-| Talkpod A36plus                |  ✅   |  ✅    |   ❌    |   ❌    |   ❌    |   ❌     |   ❌    |  ❌     |   ❌    |
-| Retevis C62                    |  ✅   |  ❌    |   ❌    |   ❌    |   ❌    |   ❌     |   ❌    |  ❌     |   ❌    |
-| Connect Systems CS7000-M17     |  ✅   |  ✅    |   ✅    |   ✅   |   ❌     |   ❌     |   ❌   |   ❌    |   ❌     |
-| Connect Systems CS7000-M17 Plus|  ✅   |  ✅    |   ✅    |   ✅   |   ❌     |   ❌     |   ❌   |   ❌    |   ❌     |
+| Tytera MD-380 / MD-390         | ✅    | ✅    | ✅     | ✅     | ❌      | ❌      | ❌     | ❌     | ❌      |
+| Tytera MD-UV380 / Retevis RT3s | ✅    | ✅    | ✅     | ✅     | ❌      | ❌      | ❌     | ❌     | ❌      |
+| Radioddity GD-77               | ✅    | ✅    | N/A    | N/A    | ❌      | ❌      | ❌     | ❌     | ❌      |
+| Baofeng DM-1801                | ✅    | ✅    | N/A    | N/A    | ❌      | ❌      | ❌     | ❌     | ❌      |
+| Tytera MD-9600                 | ❌    | ❌    | ❌     | ❌     | ❌      | ❌      | ❌     | ❌     | ❌      |
+| Module 17                      | N/A   | N/A   | ✅     | ✅     | N/A     | N/A     | N/A    | N/A    | N/A     |
+| Lilygo T-TWR plus              | ✅    | ✅    | ❌     | ❌     | ❌      | ❌      | N/A    | N/A    | N/A     |
+| Radtel RT-890                  | ❌    | ❌    | ❌     | ❌     | ❌      | ❌      | ❌     | ❌     | ❌      |
+| Talkpod A36plus                | ✅    | ✅    | ❌     | ❌     | ❌      | ❌      | ❌     | ❌     | ❌      |
+| Retevis C62                    | ✅    | ❌    | ❌     | ❌     | ❌      | ❌      | ❌     | ❌     | ❌      |
+| Connect Systems CS7000-M17     | ✅    | ✅    | ✅     | ✅     | ❌      | ❌      | ❌     | ❌     | ❌      |
+| Connect Systems CS7000-M17 Plus| ✅    | ✅    | ✅     | ✅     | ❌      | ❌      | ❌     | ❌     | ❌      |
 
 
 ### Notes:


### PR DESCRIPTION
This PR:

- Fixes formatting on the tables by aligning columns
- Differentiates between the VHF and UHF variants of the MD380/MD390 to avoid confusion for users buying a radio.
- Adds additional columns to the Basic Functions table.
  - Feedback welcome if instead, a single "Other" column should added with footnotes (*, †, ‡, etc) to save space
- Adds additional column to the Modes table, "AM RX", with all radios marked `N/A` except the Talkpod A36plus, which is marked as `🟡`
- The Modes table has been updated to reflect that the Radtel RT-890 and Talkpod A36plus aren't DMR-capable radios, so any DMR columns have been changed from `❌` to `N/A`.

A 2nd set of eyes on this would be welcome for factual accuracy. Redman suggested that @Tunas1337 might have the latest info about the A36 specifically :slightly_smiling_face: 